### PR TITLE
Jax jvp

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -39,6 +39,9 @@ class DeepONetCartesianProd(nn.Module):
         branch_out = self.branch(branch_in)
         # only trunk output is activated before einsum
         trunk_out = nn.tanh(self.trunk(trunk_in))
-        out = jnp.einsum("bi,ni->bn", branch_out, trunk_out)
+        if branch_out.ndim == 2 and trunk_out.ndim == 2:
+            out = jnp.einsum("bi,ni->bn", branch_out, trunk_out)
+        else:
+            out = jnp.sum(branch_out * trunk_out, axis=-1)
         out += self.bias
         return out

--- a/xtrain_baseline.py
+++ b/xtrain_baseline.py
@@ -18,17 +18,7 @@ from src.utils import mse_to_zeros, batched_l2_relative_error, DiffRecData
 
 
 def compute_u_pde(forward_fn, branch_input, trunk_input, source_input):
-    """ diffusion-reaction equation with VMAP over function dimension
-
-    Args:
-        forward_fn: forward function
-        branch_input: shape (n_functions, n_branch_points)
-        trunk_input: shape (n_coordinates, n_dim)
-        source_input: source input
-        branch_tangent: tangent of branch_input, shape (n_branch_points,)
-        trunk_tangent: tangent of trunk_input, shape (n_dim,)
-
-    """
+    """ diffusion-reaction equation with VMAP over function dimension """
     branch_tangent = jnp.zeros(branch_input.shape)
     trunk_tangent_x = jnp.array([1., 0.])
     trunk_tangent_t = jnp.array([0., 1.])


### PR DESCRIPTION
I have enhanced the xtrain_baseline.py script by substituting jax.grad with jax.jvp. This modification has resulted in a speed increase for xtrain_baseline.py when executed on CPUs.

However, I am currently in the process of understanding ZCS and have not yet applied the same changes to xtrain_zcs.py.